### PR TITLE
don't 'use Dancer2' since this breaks compat with new Plugin code

### DIFF
--- a/lib/Dancer2/Plugin/Feed.pm
+++ b/lib/Dancer2/Plugin/Feed.pm
@@ -1,6 +1,5 @@
 package Dancer2::Plugin::Feed;
 
-use Dancer2;
 use Dancer2::Plugin;
 use XML::Feed;
 


### PR DESCRIPTION
New Dancer2::Plugin (not yet released) breaks when a plugin imports
Dancer2 package. Plugins do not need to 'use Dancer2'.