### PR TITLE
fix typo feed_properites -> feed_properties

### DIFF
--- a/lib/Dancer2/Plugin/Feed.pm
+++ b/lib/Dancer2/Plugin/Feed.pm
@@ -69,7 +69,7 @@ sub _create_feed {
     my $feed     = XML::Feed->new($format);
     my $settings = plugin_setting;
 
-    foreach (@feed_properites) {
+    foreach (@feed_properties) {
         my $val = $params->{$_} || $settings->{$_};
         $feed->$_($val) if ($val);
     }


### PR DESCRIPTION
Typo in variable name introduced by PR #4. Just spotted this when testing latest release.